### PR TITLE
fix port in api mode

### DIFF
--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - "./:/app"
     ports:
-      - "8000:8000"
+      - "7870:7870"
     environment:
       NVIDIA_VISIBLE_DEVICES: all
     command: >


### PR DESCRIPTION
launch.py实际绑定的默认port和说明中的默认端口都是7870