### PR TITLE
fix: topK and topP not valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/modules/ChatTTS/ChatTTS/core.py
+++ b/modules/ChatTTS/ChatTTS/core.py
@@ -700,7 +700,5 @@ class Chat:
         )
 
         del emb, input_ids
-        del_all(logits_warpers)
-        del_all(logits_processors)
 
         return result


### PR DESCRIPTION
这里的

```
del_all(logits_warpers)
del_all(logits_processors)
```
是有问题的。原因是`generate`返回是用的`yield`。导致内部函数没有执行，这两个对象就已经被删除了。

实际测试时，就发现因为这两个对象被删除了，导致一些bad case，例如音色设置的是female2，但输出是一个男声。 删除后，bad case明显大幅度减少