### PR TITLE
replace chattts modelscope_repo with AI-ModelScope

### DIFF
--- a/requirements.windows.txt
+++ b/requirements.windows.txt
@@ -35,7 +35,8 @@ pyrubberband
 pybase16384
 cachetools
 langdetect
-# NOTE: wetext 依赖 pynini 无法在 Windows 上安装
+# NOTE: 截至2024/08/13，WeTextProcessing 安裝方法，需要在conda环境下，执行命令 conda install -c conda-forge pynini==2.1.6
+# NOTE: 然后再执行命令 pip install WeTextProcessing==1.0.4
 # WeTextProcessing
 
 #### fish-speech

--- a/scripts/dl_chattts.py
+++ b/scripts/dl_chattts.py
@@ -23,7 +23,7 @@ class ChatTTSDownloader(BaseModelDownloader):
         ]
         super().__init__(
             model_name="ChatTTS",
-            modelscope_repo="pzc163/chatTTS",
+            modelscope_repo="AI-ModelScope/ChatTTS",
             huggingface_repo="2Noise/ChatTTS",
             required_files=required_files,
         )


### PR DESCRIPTION
old pzc163/chatTTS repo missed "asset/DVAE_full.pt" so replace it with AI-ModelScope
update the instruction of installing WeTextProcessing in Windows